### PR TITLE
rimage: update for the new rimage command-line parameters

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -425,7 +425,8 @@ class RimageSigner(Signer):
         board = cache['CACHED_BOARD']
         log.inf('Signing for board ' + board)
         target = self.edt_get_rimage_target(board)
-        log.inf('Signing for SOC target ' + target)
+        conf = target + '.toml'
+        log.inf('Signing for SOC target ' + target + ' using ' + conf)
 
         if not args.quiet:
             log.inf('Signing with tool {}'.format(tool_path))
@@ -433,9 +434,10 @@ class RimageSigner(Signer):
         bootloader = str(b / 'zephyr' / 'bootloader.elf.mod')
         kernel = str(b / 'zephyr' / 'zephyr.elf.mod')
         out_bin = str(b / 'zephyr' / 'zephyr.ri')
+        conf_path = str(b / '../modules/audio/sof/rimage/config' / conf)
 
         sign_base = ([tool_path] + args.tool_args +
-                     ['-o', out_bin, '-m', target, '-i', '3'] +
+                     ['-o', out_bin, '-c', conf_path, '-i', '3'] +
                      [bootloader, kernel])
 
         if not args.quiet:


### PR DESCRIPTION
rimage dropped its "-m" parameter and switched over to using "-c" for a configuration file, including a target name. This is just an example, probably wrong, because it hard-codes location of the source directory WRT the build directory.

Instead of fixing for the new rimage interface, we can for now just fix an earlier version. Another possibility would be to not include native rimage and meu signing support into Zephyr but maybe just call an SOF wrapper? Or do we expect other modules to also use rimage for signing?